### PR TITLE
Set targetSdkVersion to 23

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ subprojects {
 
         defaultConfig {
             minSdkVersion 1
+            targetSdkVersion 23
             versionCode 1
             versionName project.version
         }


### PR DESCRIPTION
Otherwise app's using the library get
```
android:uses-permission#android.permission.READ_PHONE_STATE
IMPLIED from C:\Users\Michael\git\rpicheck\app\src\main\AndroidManifest.xml:2:1-107:12 reason: io.freefair.android.util has a targetSdkVersion < 4
```